### PR TITLE
support prefixing with /

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ Router.prototype.prefix = function prefix(uri, fn) {
         throw new Error(msg)
     }
 
-    if (uri[uri.length - 1] === '/') {
+    if (uri[uri.length - 1] === '/' && uri.length > 1) {
         msg = 'routes-router: ' +
             '`routes.prefix("/some-prefix/", fn)` is ' +
             'invalid.\n' +
@@ -68,7 +68,7 @@ Router.prototype.prefix = function prefix(uri, fn) {
         throw new Error(msg)
     }
 
-    var pattern = uri + "/*?";
+    var pattern = uri === "/" ? "/*?" : uri + "/*?";
 
     if (typeof fn === "object") {
         fn = methods(fn)

--- a/test/prefix-tests.js
+++ b/test/prefix-tests.js
@@ -226,3 +226,52 @@ test("child inherits params", function (assert) {
             assert.end()
         }))
 })
+
+test("can prefix at /", function (assert) {
+    var child = Router()
+    child.addRoute("/", function (req, resp) {
+        resp.end("/")
+    })
+    child.addRoute("/foo", function (req, resp) {
+        resp.end("/foo")
+    })
+    child.addRoute("/:id", function (req, resp) {
+        resp.end("/:id")
+    })
+
+    var parent = Router()
+    parent.prefix("/", child)
+
+    request(parent, {
+        url: "/"
+    }, function (err, resp) {
+        assert.ifError(err)
+
+        assert.equal(resp.body, "/")
+
+        request(parent, {
+            url: "/foo"
+        }, function (err, resp) {
+            assert.ifError(err)
+
+            assert.equal(resp.body, "/foo")
+
+            request(parent, {
+                url: "/bar"
+            }, function (err, resp) {
+                assert.ifError(err)
+
+                assert.equal(resp.body, "/:id")
+
+                assert.end()
+            })
+
+        })
+    })
+})
+
+function request(handler, req, cb) {
+    handler(
+        MockRequest(req),
+        MockResponse(cb));
+}


### PR DESCRIPTION
This fixes a bug where you couldn't call `.prefix('/', fn)`.

We now handle `'/'` with a special case.

cc @Matt-Esch @jwolski
