### PR TITLE
expose route.next() to allow match continuation

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,8 @@ Router.prototype.handleRequest =
 
         var params = extend(opts, {
             params: extend(opts.params, route.params),
-            splats: opts.splats.concat(route.splats)
+            splats: opts.splats.concat(route.splats),
+            next: route.next
         })
 
         if (uri) {


### PR DESCRIPTION
Found myself wanting to use the routes module's `match.next()` method with this module.
I'm not sure if this is the best way to expose it, but it works with usage like this:

```
router.addRoute('*', function (req, res, opts) {
  // do something like check auth
  var match = opts.next();
  if (match) match.fn(req, res, match);
});
```