### PR TITLE
Upgrade to routes v2.1.0, add support for removing routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ Router.prototype.addRoute = function addRoute(uri, fn) {
     this.router.addRoute(uri, fn)
 }
 
+Router.prototype.removeRoute = function removeRoute(uri) {
+    this.router.removeRoute(uri);
+}
+
 Router.prototype.prefix = function prefix(uri, fn) {
     var msg;
     if (typeof uri !== 'string') {
@@ -151,6 +155,7 @@ function createRouter(opts) {
     var handleRequest = router.handleRequest.bind(router)
     return mutableExtend(handleRequest, router, {
         addRoute: router.addRoute,
+        removeRoute: router.removeRoute,
         prefix: router.prefix,
         handleRequest: router.handleRequest
     })

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "http-methods": "~0.1.0",
     "httperr": "^0.5.0",
     "inherits": "^2.0.1",
-    "routes": "^1.1.0",
+    "routes": "^2.1.0",
     "send-data": "^3.2.4",
     "xtend": "~2.1.1"
   },

--- a/test/unit.js
+++ b/test/unit.js
@@ -180,3 +180,38 @@ test("opts has parsedUrl", function (assert) {
             assert.end()
         }))
 })
+
+test("can call removeRoute() on router", function (assert) {
+    var router = Router()
+
+    router.addRoute("/win", function (req, res) {
+        res.end("winning")
+    })
+
+    router.addRoute("/lose", function (req, res) {
+        res.end("losing")
+    })
+
+    router.removeRoute("/lose");
+
+    router(
+        new MockRequest({ url: "/win" }),
+        new MockResponse(function (err, resp) {
+            assert.ifError(err)
+
+            assert.equal(resp.body, "winning")
+        })
+    )
+
+    router(
+        new MockRequest({ uri: "/lose" }),
+        MockResponse(function (err, resp) {
+            assert.ifError(err)
+
+            assert.equal(resp.statusCode, 404)
+            assert.equal(resp.body, "404 Not Found")
+
+            assert.end()
+        })
+    )
+})


### PR DESCRIPTION
This follows the change I made in aaronblohowiak/routes.js#40 to add support for removing routes.