### PR TITLE
[routes router] add a pre handle hook to access route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ compile
 .lock-wscript
 node_modules/
 coverage/
+.idea
+

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ Router.prototype.handleRequest =
             opts = null
         }
 
-        opts = opts || {}
+        opts = opts || {};
         callback = callback ||
             this.defaultHandler.bind(null, req, res)
 
@@ -125,7 +125,7 @@ Router.prototype.handleRequest =
             pathname = uri.pathname;
         }
 
-        var route = this.router.match(pathname)
+        var route = this.router.match(pathname);
 
         if (!route) {
             return callback(NotFound({
@@ -139,10 +139,23 @@ Router.prototype.handleRequest =
         })
 
         if (uri) {
-            params.parsedUrl = uri
+            params.parsedUrl = uri;
         }
 
-        route.fn(req, res, params, callback)
+        if (typeof opts.preHandleHook === 'function') {
+            var reqOpts = {
+                route: route,
+                params: params,
+                opts: opts
+            };
+            opts.preHandleHook({
+                req: req,
+                reqOpts: reqOpts
+            });
+            route.fn(req, res, params, callback);
+        } else {
+            route.fn(req, res, params, callback);
+        }
     }
 
 createRouter.Router = Router

--- a/test/unit.js
+++ b/test/unit.js
@@ -181,6 +181,27 @@ test("opts has parsedUrl", function (assert) {
         }))
 })
 
+test("preHandleHook is called", function(assert) {
+var router = Router();
+
+    router.addRoute("/foo", function (req, res, opts) {
+        res.end(opts.route.route);
+    });
+
+    var opts = {};
+    opts.preHandleHook = function preHandleHook(params) {
+        params.reqOpts.params.route = params.reqOpts.route;
+    };
+    router(
+        MockRequest({ url: "/foo?hello=there" }),
+        MockResponse(function (err, resp) {
+            assert.ifError(err)
+            assert.equal(resp.body, "/foo")
+            assert.end()
+        }),
+        opts);
+})
+
 test("can call removeRoute() on router", function (assert) {
     var router = Router()
 


### PR DESCRIPTION
I initially tried adding a separate method to router for mapping url to route, but this doesn't work when the router is wrapped in function. I think using hook is the cleanest way.